### PR TITLE
Stop the documentation buffer from jumping around

### DIFF
--- a/gnu-apl-documentation.el
+++ b/gnu-apl-documentation.el
@@ -154,11 +154,11 @@
   (let ((string (gnu-apl--get-full-docstring-for-symbol symbol)))
     (unless string
       (user-error "No documentation available for %s" symbol))
-    (let ((old-buffer (get-buffer *gnu-apl-documentation-buffer-name*)))
-      (when old-buffer
-        (kill-buffer old-buffer)))
-    (let ((buffer (get-buffer-create *gnu-apl-documentation-buffer-name*)))
+    (let ((buffer (get-buffer *gnu-apl-documentation-buffer-name*)))
+      (unless buffer
+        (setq buffer (get-buffer-create *gnu-apl-documentation-buffer-name*)))
       (with-current-buffer buffer
+        (read-only-mode 0)
         (delete-region (point-min) (point-max))
         (insert string)
         (goto-char (point-min))


### PR DESCRIPTION
Instead of always creating a new buffer.
Just use the old one if it's there (create if not).

So that if I place the documentation buffer at one place, it doesn't get moved around when I request the documentation of another operator.