### PR TITLE
Customize keymap prefix then rebuild keymap

### DIFF
--- a/gnu-apl-interactive.el
+++ b/gnu-apl-interactive.el
@@ -194,8 +194,9 @@ function editor.
                     (add-to-result command))))))))
     result))
 
-(defvar gnu-apl-interactive-mode-map
-  (let ((map (gnu-apl--make-mode-map "s-")))
+(defun gnu-apl--make-interactive-mode-map ()
+  (message "Creating `gnu-apl-interactive-mode-map' with prefix %S." gnu-apl-interactive-mode-map-prefix)
+  (let ((map (gnu-apl--make-base-mode-map gnu-apl-interactive-mode-map-prefix)))
     (define-key map (kbd "TAB") 'completion-at-point)
     (define-key map (kbd "C-c C-f") 'gnu-apl-edit-function)
     (define-key map (kbd "C-c C-v") 'gnu-apl-edit-variable)
@@ -203,7 +204,28 @@ function editor.
     (define-key map [menu-bar gnu-apl edit-function] '("Edit function" . gnu-apl-edit-function))
     (define-key map [menu-bar gnu-apl edit-matrix] '("Edit variable" . gnu-apl-edit-variable))
     (define-key map [menu-bar gnu-apl plot-line] '("Plot line graph of variable content" . gnu-apl-plot-line))
-    map)
+    map))
+
+(defun gnu-apl--set-interactive-mode-map-prefix (symbol new)
+  "Recreate the prefix and the keymap."
+  (message "Changing `gnu-apl-interactive-mode-map-prefix' from %S to %S."
+           (if (boundp symbol) (symbol-value symbol)
+             nil)
+           new)
+  (set-default symbol new)
+  (message "Updating `gnu-apl-interactive-mode-map'.")
+  (setq gnu-apl-interactive-mode-map (gnu-apl--make-interactive-mode-map)))
+
+(defcustom gnu-apl-interactive-mode-map-prefix "s-"
+  "The keymap prefix for ‘gnu-apl-interactive-mode-map’ used both to store the new value
+using `set-create' and to update `gnu-apl-interactive-mode-map' using
+  `gnu-apl--make-interactive-mode-map'. Kill and re-start your interactive APL
+  buffers to reflect the change."
+  :type 'string
+  :group 'gnu-apl
+  :set 'gnu-apl--set-interactive-mode-map-prefix)
+
+(defvar gnu-apl-interactive-mode-map (gnu-apl--make-interactive-mode-map)
   "The keymap for ‘gnu-apl-interactive-mode'.")
 
 (define-derived-mode gnu-apl-interactive-mode comint-mode "GNU-APL/Comint"

--- a/gnu-apl-mode.el
+++ b/gnu-apl-mode.el
@@ -203,7 +203,7 @@ character when using the super-prefixed characters."
   (interactive)
   (insert " "))
 
-(defun gnu-apl--make-mode-map (prefix)
+(defun gnu-apl--make-base-mode-map (prefix)
   (let ((map (make-sparse-keymap)))
     (dolist (command gnu-apl--symbols)
       (let ((key-sequence (caddr command)))
@@ -225,13 +225,34 @@ character when using the super-prefixed characters."
         (define-key map [menu-bar gnu-apl trace] '("Trace variable" . gnu-apl-trace))))
     map))
 
-(defvar gnu-apl-mode-map
-  (let ((map (gnu-apl--make-mode-map "s-")))
+(defun gnu-apl--make-apl-mode-map ()
+  (message "Creating `gnu-apl-mode-map' with prefix %S." gnu-apl-mode-map-prefix)
+  (let ((map (gnu-apl--make-base-mode-map gnu-apl-mode-map-prefix)))
     (define-key map (kbd "C-c r") 'gnu-apl-interactive-send-region)
     (define-key map (kbd "C-c C-c") 'gnu-apl-interactive-send-current-function)
     (define-key map (kbd "C-c C-l") 'gnu-apl-interactive-send-buffer)
     (define-key map (kbd "C-c C-z") 'gnu-apl-switch-to-interactive)
-    map)
+    map))
+
+(defun gnu-apl--set-mode-map-prefix (symbol new)
+  "Recreate the prefix and the keymap."
+  (message "Changing `gnu-apl-mode-map-prefix' from %S to %S."
+           (if (boundp symbol) (symbol-value symbol)
+             nil)
+           new)
+  (set-default symbol new)
+  (message "Updating `gnu-apl-mode-map'.")
+  (setq gnu-apl-mode-map (gnu-apl--make-apl-mode-map)))
+
+(defcustom gnu-apl-mode-map-prefix "s-"
+  "The keymap prefix for ‘gnu-apl-mode-map’ used both to store the new value
+using `set-create' and to update `gnu-apl-mode-map' using
+  `gnu-apl--make-apl-mode-map'. Kill and re-start your APL buffers to reflect the change."
+  :type 'string
+  :group 'gnu-apl
+  :set 'gnu-apl--set-mode-map-prefix)
+
+(defvar gnu-apl-mode-map (gnu-apl--make-apl-mode-map)
   "The keymap for ‘gnu-apl-mode’.")
 
 (defvar gnu-apl-mode-syntax-table


### PR DESCRIPTION
Good evening Elias,

Attached is the change that rebuilds the keymap after the user changes the
prefix along with my notes and testing results.

-   gnu-apl-mode.el
    -   Added a base-constructor to build the common keymap between edit and
        interactive mode
    -   Added a constructor to build the edit keymap
        -   Is not interactive because the defcustom doc string explains things
        -   Uses the base keymap constructor
        -   [This code from yasnippet](https://github.com/joaotavora/yasnippet/blob/master/yasnippet.el#L183-L189) shows how to correctly handle referring to the
            perhaps not yet initialized value for the prefix. This was key to getting
            this defcustom setter working correctly
    -   Added defcustom for prefix
        -   Setter function sets using the default `set-value` and then rebuilds the
            keymap
    -   The keymap is declared using the constructor
-   gnu-apl-interactive.el (changes are virtually identical)
    -   Added a constructor to build the keymap
        -   Is not interactive because the defcustom doc string explains things
        -   Uses the base keymap constructor
    -   Added defcustom for prefix
        -   Setter function sets using the default `set-value` and then rebuilds the
            keymap
    -   The keymap is declared using the constructor
-   Testing
    
    <table>
    
    
    <colgroup>
    <col  class="org-left">
    
    <col  class="org-left">
    
    <col  class="org-left">
    
    <col  class="org-left">
    
    <col  class="org-left">
    </colgroup>
    <thead>
    <tr>
    <th scope="col" class="org-left">Mode</th>
    <th scope="col" class="org-left">Buffer Open</th>
    <th scope="col" class="org-left">Set prefix</th>
    <th scope="col" class="org-left">Expectation</th>
    <th scope="col" class="org-left">Result</th>
    </tr>
    </thead>
    
    <tbody>
    <tr>
    <td class="org-left">Edit file</td>
    <td class="org-left">No</td>
    <td class="org-left">Session</td>
    <td class="org-left">Set prefix when open, correct prefix</td>
    <td class="org-left">Pass</td>
    </tr>
    
    
    <tr>
    <td class="org-left">Edit file</td>
    <td class="org-left">Yes</td>
    <td class="org-left">Session</td>
    <td class="org-left">Set prefix, close buffer, open file, correct prefix</td>
    <td class="org-left">Pass</td>
    </tr>
    
    
    <tr>
    <td class="org-left">Edit file</td>
    <td class="org-left">No</td>
    <td class="org-left">Saved</td>
    <td class="org-left">Set prefix when open, correct prefix</td>
    <td class="org-left">Pass</td>
    </tr>
    
    
    <tr>
    <td class="org-left">Edit file</td>
    <td class="org-left">Yes</td>
    <td class="org-left">Saved</td>
    <td class="org-left">Set prefix, close buffer, open file, correct prefix</td>
    <td class="org-left">Pass</td>
    </tr>
    
    
    <tr>
    <td class="org-left">Interactive</td>
    <td class="org-left">No</td>
    <td class="org-left">Session</td>
    <td class="org-left">Set prefix when open, correct prefix</td>
    <td class="org-left">Pass</td>
    </tr>
    
    
    <tr>
    <td class="org-left">Interactive</td>
    <td class="org-left">Yes</td>
    <td class="org-left">Session</td>
    <td class="org-left">Set prefix, close buffer, restart session, correct prefix</td>
    <td class="org-left">Pass</td>
    </tr>
    
    
    <tr>
    <td class="org-left">Interactive</td>
    <td class="org-left">No</td>
    <td class="org-left">Saved</td>
    <td class="org-left">Set prefix when open, correct prefix</td>
    <td class="org-left">Pass</td>
    </tr>
    
    
    <tr>
    <td class="org-left">Interactive</td>
    <td class="org-left">Yes</td>
    <td class="org-left">Saved</td>
    <td class="org-left">Set prefix, close buffer, restart session, correct prefix</td>
    <td class="org-left">Pass</td>
    </tr>
    </tbody>
    </table>
    
Sincerely,

Grant Rettke
