### PR TITLE
Added support for help command

### DIFF
--- a/gnu-apl-mode.el
+++ b/gnu-apl-mode.el
@@ -453,6 +453,46 @@ This function is designed to be used in ‘completion-at-point-functions’."
                   (list pos (point) filtered-variables))))))))))
 
 ;;;
+;;;  remote help command integration
+;;;
+
+(defun gnu-apl--load-help (&optional string)
+  "Retrieve the help from GNU APL for a symbol STRING and
+convert it to the format same as `gnu-apl--symbol-doc'.
+If STRING is nil return help for all symbols"
+  (let* ((results (gnu-apl--send-network-command-and-read
+                   (if string (concat "help:" string) "help")))
+         (entries (mapcar (lambda (x) (car (read-from-string x))) results))
+         (uniq-symbols (mapcar #'second
+                               (seq-uniq entries
+                                         (lambda (x y)
+                                           (string= (second x) (second y))))))
+         (docs))
+    (flet ((cnv (entry)
+                (let ((arity (first entry)))
+                  (list (case arity
+                          (0 "Niladic function")
+                          (1 "Monadic function")
+                          (2 "Dyadic function")
+                          (-1 "Monadic operator taking one argument")
+                          (-2 "Monadic operator taking one or two arguments")
+                          (-3 "Dyadic operator taking one argument")
+                          (-4 "Dyadic operator taking two arguments")
+                          (-5 "Quasi-dyadic operator (outer product)"))
+                      (third entry)
+                      (fourth entry)
+                      (fifth entry)))))
+      (dolist (symb uniq-symbols)
+        (push
+         (list symb
+               (mapcar #'cnv
+                       (cl-remove-if-not (lambda (x) (string= (second x) symb)) entries)))
+         docs)))
+    docs))
+
+                               
+
+;;;
 ;;;  imenu integration
 ;;;
 
@@ -549,8 +589,7 @@ to ‘gnu-apl-executable’)."
                                       "'" *gnu-apl-native-lib* "'"))
         (gnu-apl--send buffer (format "%s[1] %d" *gnu-apl-native-lib* gnu-apl-native-listener-port))
         (gnu-apl--send buffer (concat "'" *gnu-apl-network-end* "'"))))
-    (when gnu-apl-show-keymap-on-startup
-      (run-at-time "0 sec" nil #'(lambda () (gnu-apl-show-keyboard 1))))))
+    (when gnu-apl-show-keymap-on-startup      (run-at-time "0 sec" nil #'(lambda () (gnu-apl-show-keyboard 1))))))
 
 ;;;
 ;;;  Load the other source files

--- a/gnu-apl-network.el
+++ b/gnu-apl-network.el
@@ -7,6 +7,9 @@
 (defvar *gnu-apl-notification-start* "APL_NATIVE_NOTIFICATION_START")
 (defvar *gnu-apl-notification-end* "APL_NATIVE_NOTIFICATION_END")
 (defvar *gnu-apl-protocol* "1.5")
+(defvar *gnu-apl-remote-protocol* nil
+  "The received version of a protocol on GNU APL side")
+
 
 ;;; We really should be using define-error here, but that function is
 ;;; new in 24.4 and thus is not generally available yet. This should
@@ -57,7 +60,8 @@ connect mode in use."
     (condition-case err
         (let ((version (gnu-apl--send-network-command-and-read "proto")))
           (unless (gnu-apl--protocol-acceptable-p (car version))
-            (error "GNU APL version too old (%s). Please upgrade to at least %s" (car version) *gnu-apl-protocol*)))
+            (error "GNU APL version too old (%s). Please upgrade to at least %s" (car version) *gnu-apl-protocol*))
+          (setq-local *gnu-apl-remote-protocol* (car version)))
       (gnu-apl-network-proto-error (error "GNU APL version too old (<1.3). Please upgrade to at least %s" *gnu-apl-protocol*)))))
 
 (defun gnu-apl--process-notification (lines)


### PR DESCRIPTION
Help command is used to get help on symbols from GNU APL.
If it is available remotely(i.e. remote protocol version
is > 1.5), the help will be requested and the contents
of gnu-apl--symbol-doc variable will be updated.

Note that the remote help command should return a list
of S-expressions which could be easily 'read-from-string'
and processed.

Also removed duplicated gnu-apl function.