### PR TITLE
Changes in popup keyboard

### DIFF
--- a/gnu-apl-documentation.el
+++ b/gnu-apl-documentation.el
@@ -8,6 +8,18 @@
 (require 'gnu-apl-util)
 (require 'gnu-apl-network)
 
+
+(defcustom gnu-apl-keyboard-simplified-mouse-action-mode t
+  "Defines the action to be performed on mouse over the symbol in
+keyboard help. Possible variants:
+nil - tooltip shows help on possible actions,
+mouse 1 to open help window, mouse 3 to insert symbol
+t - inspired by Dyalog APL IDE toolbar, tooltip shows symbol
+help, mouse 1 to insert symbol, mouse 2 to open help window"
+  :type 'boolean
+  :group 'gnu-apl)
+
+
 (defvar *gnu-apl-keymap-buffer-name* "*gnu-apl keymap*")
 
 (defvar gnu-apl-keymap-template
@@ -28,6 +40,8 @@
 GNU APL keyboard layout: http://commons.wikimedia.org/wiki/File:GNU_APL_keyboard_layout.png
 This variable could be redefined to match another physical layout.
 In order for changes to take effect the buffer needs to be recreated.")
+
+
 
 (defun gnu-apl-keymap-mode-kill-buffer ()
   "Close the buffer displaying the keymap."
@@ -87,22 +101,26 @@ In order for changes to take effect the buffer needs to be recreated.")
         return e
         finally (return nil)))
 
-(defun gnu-apl--get-full-docstring-for-native-symbol (string)
-  (let ((doc (gnu-apl--get-doc-for-symbol string)))
+(defun gnu-apl--get-full-docstring-for-native-symbol (string full-text-p)
+  (let ((doc (gnu-apl--get-doc-for-symbol string))
+        (format-short 
+         (if full-text-p "\n%s\n\n" "\n%s\n")))
     (when doc
       (with-temp-buffer
         (loop for e in (second doc)
               for first = t then nil
               unless first
-              do (princ "\n")
+              do (insert "\n")
               do (progn
                    (insert (format "%s: %s" (first e) (second e)))
-                   (insert (format "\n%s\n\n" (third e)))
+                   (insert (format format-short (third e)))
                    (let ((long (fourth e)))
                      (when long
                        (insert (format "%s\n" long)))))
+              when full-text-p
               do (insert "\n===================================\n"))
         (buffer-string)))))
+
 
 (defun gnu-apl--remove-local-variable-name (name)
   (let ((pos (position ?\; name)))
@@ -121,8 +139,11 @@ In order for changes to take effect the buffer needs to be recreated.")
               do (insert row))
         (buffer-string)))))
 
-(defun gnu-apl--get-full-docstring-for-symbol (string)
-  (or (gnu-apl--get-full-docstring-for-native-symbol string)
+(defun gnu-apl--get-full-docstring-for-symbol (string full-text-p)
+  "Get the documentation for the symbol or function STRING.
+When FULL-TEXT is t format the output string suitable for separate
+buffer. Otherwise try to make it short to fit into the tooltip."
+  (or (gnu-apl--get-full-docstring-for-native-symbol string full-text-p)
       (gnu-apl--get-full-docstring-for-function-symbol string)))
 
 (defvar *gnu-apl-documentation-buffer-name* "*gnu-apl documentation*")
@@ -172,7 +193,7 @@ In order for changes to take effect the buffer needs to be recreated.")
                                     nil nil default-sym t))))
   (when (or (null symbol) (string= symbol ""))
     (error "Symbol is empty"))
-  (let ((string (gnu-apl--get-full-docstring-for-symbol symbol)))
+  (let ((string (gnu-apl--get-full-docstring-for-symbol symbol t)))
     (unless string
       (user-error "No documentation available for %s" symbol))
     (let ((buffer (get-buffer-create *gnu-apl-documentation-buffer-name*)))
@@ -187,13 +208,22 @@ In order for changes to take effect the buffer needs to be recreated.")
       (pop-to-buffer buffer))))
 
 (defun gnu-apl--make-clickable (string keymap)
+  (let ((help-echo-string (concat "mouse-1: Show documentation for " string "\n"
+                        "mouse-3: Insert " string " in GNU APL buffer"))
+        (description
+         (gnu-apl--get-full-docstring-for-symbol string
+                                                 (not gnu-apl-keyboard-simplified-mouse-action-mode))))
+    (cond ((and gnu-apl-keyboard-simplified-mouse-action-mode
+                description)
+           (setf help-echo-string description))           
+          (gnu-apl-keyboard-simplified-mouse-action-mode
+           (setf help-echo-string "No documentation available")))
   (propertize string
               'mouse-face 'highlight
-              'help-echo (concat "mouse-1: Show documentation for " string "\n"
-                                 "mouse-3: Insert " string " in GNU APL buffer")
+              'help-echo help-echo-string
               'gnu-apl-insert string
               'keymap keymap
-              'follow-link t))
+              )))
 
 (defun gnu-apl-mouse-insert-from-keymap (event)
   "In the keymap buffer, insert the symbol that was clicked."
@@ -202,11 +232,23 @@ In order for changes to take effect the buffer needs to be recreated.")
         (pos (posn-point (event-end event))))
     (unless (windowp window)
       (error "Can't find window"))
-    (let ((string (with-current-buffer (window-buffer window)
-                    (get-text-property pos 'gnu-apl-insert)))
-          (session (gnu-apl--get-interactive-session)))
+    (let* ((string (with-current-buffer (window-buffer window)
+                     (get-text-property pos 'gnu-apl-insert)))
+           (session (gnu-apl--get-interactive-session))
+           (interactive-session-windows
+            (get-buffer-window-list session nil 'visible)))
       (with-current-buffer session
-        (insert string)))))
+        (insert string))
+      ;; after we have inserted the special character,
+      ;; it is reasonable to switch focus back to the interactive
+      ;; APL session to continue typing.
+      ;; NOTE: if there are more than 1 visible windows
+      ;; with the same interactive session, the first
+      ;; one will be activated.
+      (when interactive-session-windows
+        (select-window (car interactive-session-windows))
+        ;; advance point after the inserted string
+        (goto-char (+ (point) (length string)))))))
 
 (defun gnu-apl-symbol-insert-from-keymap ()
   "Send a symbol from the keymap buffer to the current GNU APL interpreter."
@@ -234,9 +276,13 @@ In order for changes to take effect the buffer needs to be recreated.")
     (gnu-apl-show-help-for-symbol string)))
 
 (defun gnu-apl--make-help-property-keymap ()
-  (let ((map (make-sparse-keymap)))
-    (define-key map [down-mouse-1] 'gnu-apl-mouse-help-from-keymap)
-    (define-key map [mouse-3] 'gnu-apl-mouse-insert-from-keymap)
+  (let ((map (make-sparse-keymap)))  
+    (cond (gnu-apl-keyboard-simplified-mouse-action-mode
+           (define-key map [mouse-1] 'gnu-apl-mouse-insert-from-keymap)
+           (define-key map [down-mouse-2] 'gnu-apl-mouse-help-from-keymap))
+          (t
+           (define-key map [down-mouse-1] 'gnu-apl-mouse-help-from-keymap)
+           (define-key map [mouse-3] 'gnu-apl-mouse-insert-from-keymap)))
     (define-key map (kbd "?") 'gnu-apl-symbol-help-from-keymap)
     (define-key map (kbd "RET") 'gnu-apl-symbol-insert-from-keymap)
     map))
@@ -256,8 +302,10 @@ In order for changes to take effect the buffer needs to be recreated.")
       (while (search-forward-regexp "\\(.\\)∇" nil t)
         (let* ((key (match-string 1))
                (found (cl-find key gnu-apl--symbols :key #'third :test #'equal))
-               (result-string (if found (gnu-apl--make-clickable (second found) keymap) " ")))
-          (replace-match (concat key result-string) t t)))
+               (found-nonspecial (cl-find key gnu-apl--symbol-doc :key #'first :test #'equal))
+               (result-string (if found (gnu-apl--make-clickable (second found) keymap) " "))
+               (nonspecial-string (if found-nonspecial (gnu-apl--make-clickable key keymap) key)))
+          (replace-match (concat nonspecial-string result-string) t t)))
       (add-text-properties (point-min) (point-max) (list 'face 'gnu-apl-kbd-help-screen))
       (goto-char (point-min))
       (gnu-apl-keymap-mode))


### PR DESCRIPTION
- Implemented additonal tooltips mode:
  Added gnu-apl-keyboard-mouse-action-mode variable.
  If set to 'simplistic the keyboard help will show
  the symbol documentation in tooltip and insert
  symbol on mouse-1 event.
  The default behavior is kept as it is now.

- Fixed bug when clicking on a keyboard the message
  "buffer is read only" was presented.

- Now if user clicks on the keyboard to insert a symbol,
  the focus is moved back to interactive GNU APL session.

- Non-special APL characters are now having tooltips and
  clickable in the popup keyboard, if documentation for
  them is available.