### PR TITLE
Flet obsolete

### DIFF
--- a/gnu-apl-documentation.el
+++ b/gnu-apl-documentation.el
@@ -103,7 +103,7 @@ In order for changes to take effect the buffer needs to be recreated.")
 
 (defun gnu-apl--get-full-docstring-for-native-symbol (string full-text-p)
   (let ((doc (gnu-apl--get-doc-for-symbol string))
-        (format-short 
+        (format-short
          (if full-text-p "\n%s\n\n" "\n%s\n")))
     (when doc
       (with-temp-buffer
@@ -215,7 +215,7 @@ buffer. Otherwise try to make it short to fit into the tooltip."
                                                  (not gnu-apl-keyboard-simplified-mouse-action-mode))))
     (cond ((and gnu-apl-keyboard-simplified-mouse-action-mode
                 description)
-           (setf help-echo-string description))           
+           (setf help-echo-string description))
           (gnu-apl-keyboard-simplified-mouse-action-mode
            (setf help-echo-string "No documentation available")))
   (propertize string
@@ -276,7 +276,7 @@ buffer. Otherwise try to make it short to fit into the tooltip."
     (gnu-apl-show-help-for-symbol string)))
 
 (defun gnu-apl--make-help-property-keymap ()
-  (let ((map (make-sparse-keymap)))  
+  (let ((map (make-sparse-keymap)))
     (cond (gnu-apl-keyboard-simplified-mouse-action-mode
            (define-key map [mouse-1] 'gnu-apl-mouse-insert-from-keymap)
            (define-key map [down-mouse-2] 'gnu-apl-mouse-help-from-keymap))

--- a/gnu-apl-finnapl.el
+++ b/gnu-apl-finnapl.el
@@ -71,7 +71,7 @@ containing parsed values from this list"
           ;; parse sections updating the global list of idioms
           (dolist (x sections)
             (apply #'gnu-apl--parse-finnapl-section x))
-          ;; kill the buffer created by url-retrieve. 
+          ;; kill the buffer created by url-retrieve.
           (kill-buffer (current-buffer))
           (setq *gnu-apl--finnapl-idioms* (nreverse *gnu-apl--finnapl-idioms*))
           (message "List of APL idioms successfully downloaded")
@@ -117,7 +117,7 @@ the buffer created by url-retrieve START END."
 
 (defun gnu-apl--parse-finnapl-idiom (idiom)
   "Parse particular IDIOM part of the buffer.
-The IDIOM is a list of: 
+The IDIOM is a list of:
   - Idiom number (string)
   - Idiom name
   - Idiom arguments
@@ -183,7 +183,7 @@ and closes the idioms window."
   (let* ((id (tabulated-list-get-id))
          (idiom (fourth (cl-find id *gnu-apl--finnapl-idioms*
                                  :test #'string= :key #'car))))
-    (quit-window t)  
+    (quit-window t)
     (gnu-apl-finnapl--insert-idiom idiom)))
 
 (defun gnu-apl-finnapl-choice-tabular ()

--- a/gnu-apl-mode.el
+++ b/gnu-apl-mode.el
@@ -471,7 +471,7 @@ If STRING is nil return help for all symbols"
                                          (lambda (x y)
                                            (string= (second x) (second y))))))
          (docs))
-    (flet ((cnv (entry)
+    (cl-flet ((cnv (entry)
                 (let ((arity (first entry)))
                   (list (case arity
                           (0 "Niladic function")

--- a/gnu-apl-mode.el
+++ b/gnu-apl-mode.el
@@ -493,7 +493,7 @@ If STRING is nil return help for all symbols"
          docs)))
     docs))
 
-                               
+
 
 ;;;
 ;;;  imenu integration
@@ -597,8 +597,8 @@ to ‘gnu-apl-executable’)."
 ;;;
 ;;;  Load the other source files
 ;;;
- 
-(require 'gnu-apl-input) 
+
+(require 'gnu-apl-input)
 (require 'gnu-apl-interactive)
 (require 'gnu-apl-editor)
 (require 'gnu-apl-network)

--- a/gnu-apl-symbols.el
+++ b/gnu-apl-symbols.el
@@ -152,7 +152,7 @@
                            ;; /
                            ("slash-bar" "⌿" "/")
                            ("quad-colon" "⍠" "?")
-                           
+
                            ;; Extras
                            ("pi" "π")
                            ("root" "√")


### PR DESCRIPTION
Two commits here:
- Remove trailing whitespace and space filled lines. Add this to your emacs init if you want to see these:

```
(setf whitespace-style '(face trailing))
(global-whitespace-mode 1)
```

- Flet is now obsolete because it makes functions that are dynamically bound. You don't need (or want) that dynamic binding, so I replaced it with cl-flet. Now emacs won't warn you in a message on startup.