### PR TITLE
Allow prefix key for APL symbol input to be customised

### DIFF
--- a/gnu-apl-input.el
+++ b/gnu-apl-input.el
@@ -19,17 +19,32 @@
                       t                 ; simple
                       )
 
-(quail-select-package "APL-Z")
+(defvar gnu-apl--transcription-alist)
+(defun gnu-apl--update-key-prefix (symbol new)
+  (quail-select-package "APL-Z")
+  (quail-install-map
+   (let* ((prefix (string new))
+		  (gnu-apl--transcription-alist
+		   (loop for command in gnu-apl--symbols
+				 for key-command = (third command)
+				 append (loop for s in (if (listp key-command)
+										   key-command
+										 (list key-command))
+							  collect (cons (concat prefix s)
+											(second command))))))
+	 (quail-map-from-table
+	  '((default gnu-apl--transcription-alist)))))
+  (set-default symbol new))
 
-(macrolet ((make-quail-define-rules ()
-             (let ((prefix "."))
-               `(quail-define-rules
-                 ,@(loop for command in gnu-apl--symbols
-                         for key-command = (third command)
-                         append (loop for s in (if (listp key-command) key-command (list key-command))
-                                      collect (list (concat prefix s)
-                                                    (second command))))
-                 (,(concat prefix prefix) ,prefix)))))
-  (make-quail-define-rules))
+(defun gnu-apl--initialize-key-prefix (symbol new)
+  (custom-initialize-default symbol new)
+  (gnu-apl--update-key-prefix symbol (eval new)))
 
+(defcustom gnu-apl-key-prefix ?.
+  "Set a character to serve as prefix key for APL symbol input."
+  :type 'character
+  :group 'gnu-apl
+  :initialize #'gnu-apl--initialize-key-prefix
+  :set #'gnu-apl--update-key-prefix)
+ 
 (provide 'gnu-apl-input)

--- a/gnu-apl-input.el
+++ b/gnu-apl-input.el
@@ -24,16 +24,16 @@
   (quail-select-package "APL-Z")
   (quail-install-map
    (let* ((prefix (string new))
-		  (gnu-apl--transcription-alist
-		   (loop for command in gnu-apl--symbols
-				 for key-command = (third command)
-				 append (loop for s in (if (listp key-command)
-										   key-command
-										 (list key-command))
-							  collect (cons (concat prefix s)
-											(second command))))))
-	 (quail-map-from-table
-	  '((default gnu-apl--transcription-alist)))))
+          (gnu-apl--transcription-alist
+           (loop for command in gnu-apl--symbols
+                 for key-command = (third command)
+                 append (loop for s in (if (listp key-command)
+                                           key-command
+                                         (list key-command))
+                              collect (cons (concat prefix s)
+                                            (second command))))))
+     (quail-map-from-table
+      '((default gnu-apl--transcription-alist)))))
   (set-default symbol new))
 
 (defun gnu-apl--initialize-key-prefix (symbol new)
@@ -46,5 +46,5 @@
   :group 'gnu-apl
   :initialize #'gnu-apl--initialize-key-prefix
   :set #'gnu-apl--update-key-prefix)
- 
+
 (provide 'gnu-apl-input)


### PR DESCRIPTION
I prefer to use the ``` ` ``` key for symbol input, as I'm used to it from AucTeX, but the code seems to have hard-coded `.` as the prefix key. 

As I see no reason why this should be the case, I hope this change can help people like me, who would prefer a different key.