### PR TITLE
Add a configurable flash on send command and send line command

### DIFF
--- a/gnu-apl-editor.el
+++ b/gnu-apl-editor.el
@@ -12,7 +12,9 @@ the function and set it in the running APL interpreter."
   (gnu-apl--get-function name))
 
 (defcustom gnu-apl-flash-on-send t
-  "When non-nil flash the region that is sent to GNU APL interpreter.")
+  "When non-nil flash the region that is sent to GNU APL interpreter."
+  :type  'boolean
+  :group 'gnu-apl)
 
 (defun gnu-apl--get-function (function-definition)
   (let ((function-name (gnu-apl--parse-function-header function-definition)))
@@ -45,7 +47,7 @@ GNU APL interpreter."
   "Send the region to the active GNU APL interpreter."
   (interactive "r")
   (when gnu-apl-flash-on-send
-    (gnu-apl-flash-region start end))
+    (gnu-apl--flash-region start end))
   (gnu-apl-interactive-send-string (buffer-substring start end)
                                    buffer-file-name (1- (gnu-apl--current-line-number (min start end))))
   (message "Region sent to APL"))

--- a/gnu-apl-editor.el
+++ b/gnu-apl-editor.el
@@ -11,6 +11,9 @@ the function and set it in the running APL interpreter."
   (interactive (list (gnu-apl--choose-variable "Function name" :function (gnu-apl--name-at-point))))
   (gnu-apl--get-function name))
 
+(defvar gnu-apl-flash-on-send t
+  "When non-nil flash the region that is sent to GNU APL interpreter.")
+
 (defun gnu-apl--get-function (function-definition)
   (let ((function-name (gnu-apl--parse-function-header function-definition)))
     (unless function-name
@@ -26,6 +29,12 @@ the function and set it in the running APL interpreter."
                              (error "Not an editable function: %s" function-name)))))
         (gnu-apl--open-function-editor-with-timer content)))))
 
+(defun gnu-apl-flash-region (start end &optional timeout)
+  "Temporarily highlight region from start to end."
+  (let ((overlay (make-overlay start end)))
+    (overlay-put overlay 'face 'secondary-selection)
+    (run-with-timer (or timeout 0.2) nil 'delete-overlay overlay)))
+
 (defun gnu-apl-interactive-send-buffer ()
   "Send the entire content of the current buffer to the active
 GNU APL interpreter."
@@ -35,9 +44,16 @@ GNU APL interpreter."
 (defun gnu-apl-interactive-send-region (start end)
   "Send the region to the active GNU APL interpreter."
   (interactive "r")
+  (when gnu-apl-flash-on-send
+    (gnu-apl-flash-region start end))
   (gnu-apl-interactive-send-string (buffer-substring start end)
                                    buffer-file-name (1- (gnu-apl--current-line-number (min start end))))
   (message "Region sent to APL"))
+
+(defun gnu-apl-interactive-send-line ()
+  "Send the current to the GNU APL interpreter."
+  (interactive "r")
+  (gnu-apl-interactive-send-region (point-at-bol) (point-at-eol)))
 
 (defun gnu-apl--function-definition-to-list (content)
   "Given a function definition as returned by ⌷CR 'function',

--- a/gnu-apl-editor.el
+++ b/gnu-apl-editor.el
@@ -52,7 +52,7 @@ GNU APL interpreter."
 
 (defun gnu-apl-interactive-send-line ()
   "Send the current to the GNU APL interpreter."
-  (interactive "r")
+  (interactive)
   (gnu-apl-interactive-send-region (point-at-bol) (point-at-eol)))
 
 (defun gnu-apl--function-definition-to-list (content)

--- a/gnu-apl-editor.el
+++ b/gnu-apl-editor.el
@@ -11,7 +11,7 @@ the function and set it in the running APL interpreter."
   (interactive (list (gnu-apl--choose-variable "Function name" :function (gnu-apl--name-at-point))))
   (gnu-apl--get-function name))
 
-(defvar gnu-apl-flash-on-send t
+(defcustom gnu-apl-flash-on-send t
   "When non-nil flash the region that is sent to GNU APL interpreter.")
 
 (defun gnu-apl--get-function (function-definition)
@@ -29,7 +29,7 @@ the function and set it in the running APL interpreter."
                              (error "Not an editable function: %s" function-name)))))
         (gnu-apl--open-function-editor-with-timer content)))))
 
-(defun gnu-apl-flash-region (start end &optional timeout)
+(defun gnu-apl--flash-region (start end &optional timeout)
   "Temporarily highlight region from start to end."
   (let ((overlay (make-overlay start end)))
     (overlay-put overlay 'face 'secondary-selection)

--- a/gnu-apl-mode.el
+++ b/gnu-apl-mode.el
@@ -231,6 +231,7 @@ character when using the super-prefixed characters."
 (defun gnu-apl--make-apl-mode-map ()
   (let ((map (gnu-apl--make-base-mode-map gnu-apl-mode-map-prefix)))
     (define-key map (kbd "C-c C-s") 'gnu-apl-interactive-send-region)
+    (define-key map (kbd "C-c C-f") 'gnu-apl-interactive-send-line)
     (define-key map (kbd "C-c C-c") 'gnu-apl-interactive-send-current-function)
     (define-key map (kbd "C-c C-l") 'gnu-apl-interactive-send-buffer)
     (define-key map (kbd "C-c C-z") 'gnu-apl-switch-to-interactive)
@@ -493,7 +494,7 @@ If STRING is nil return help for all symbols"
          docs)))
     docs))
 
-                               
+
 
 ;;;
 ;;;  imenu integration
@@ -597,8 +598,8 @@ to ‘gnu-apl-executable’)."
 ;;;
 ;;;  Load the other source files
 ;;;
- 
-(require 'gnu-apl-input) 
+
+(require 'gnu-apl-input)
 (require 'gnu-apl-interactive)
 (require 'gnu-apl-editor)
 (require 'gnu-apl-network)


### PR DESCRIPTION
I'm writing a `spacemacs` layer for `gnu-apl` and thought I would add some small niceties. All this PR does is add a function to flash regions when they are sent to the apl interpreter which can be disabled and a send line function. Any comments welcome.