### PR TITLE
Fixing byte compilation issues

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,6 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((emacs-lisp-mode . ((fill-column . 120)
+		     (sentence-end-double-space . nil)
+		     (indent-tabs-mode . nil))))

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ GPATH
 GRTAGS
 GSYMS
 GTAGS
+*.elc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.POSIX:
+.PHONY: all compile test clean
+.SUFFIXES: .el .elc
+
+EMACS = lemacs
+BYTEC = gnu-apl-documentation.elc \
+	gnu-apl-editor.elc \
+	gnu-apl-finnapl.elc \
+	gnu-apl-follow.elc \
+	gnu-apl-input.elc \
+	gnu-apl-interactive.elc \
+	gnu-apl-mode.elc \
+	gnu-apl-network.elc \
+	gnu-apl-osx-workaround.elc \
+	gnu-apl-plot.elc \
+	gnu-apl-refdocs-bsd-license.elc \
+	gnu-apl-spreadsheet.elc \
+	gnu-apl-symbols.elc \
+	gnu-apl-util.elc
+
+all: compile
+
+compile: $(BYTEC)
+
+clean:
+	rm -f $(BYTEC)
+
+.el.elc:
+	$(EMACS) -Q --batch -L . -f batch-byte-compile $^
+

--- a/gnu-apl-documentation.el
+++ b/gnu-apl-documentation.el
@@ -1,13 +1,17 @@
 ;;; -*- lexical-binding: t -*-
 
-;;;
-;;; Keymap buffer
-;;;
-
 (require 'cl-lib)
 (require 'gnu-apl-util)
 (require 'gnu-apl-network)
+(require 'gnu-apl-refdocs-bsd-license)
+(require 'gnu-apl-symbols)
 
+(declare-function gnu-apl--parse-function-header "gnu-apl-mode" (string))
+(declare-function gnu-apl--get-interactive-session "gnu-apl-interactive" ())
+
+;;;
+;;; Keymap buffer
+;;;
 
 (defcustom gnu-apl-keyboard-simplified-mouse-action-mode t
   "Defines the action to be performed on mouse over the symbol in
@@ -409,7 +413,7 @@ if it is open."
                (symname-aliases (car doc))
                (name (if (listp symname-aliases) (car symname-aliases) symname-aliases)))
           (insert-button (cadr s)
-                         'action #'(lambda (event) (gnu-apl-show-help-for-symbol name))
+                         'action #'(lambda (_event) (gnu-apl-show-help-for-symbol name))
                          'follow-link t))
         (insert "\n"))
       (add-text-properties (point-min) (point-max) '(face gnu-apl-help))

--- a/gnu-apl-finnapl.el
+++ b/gnu-apl-finnapl.el
@@ -82,7 +82,7 @@ containing parsed values from this list"
 
 
 
-(defun gnu-apl--parse-finnapl-section (name start end)
+(defun gnu-apl--parse-finnapl-section (_name start end)
   "Parse a section with the name NAME and boundaries in
 the buffer created by url-retrieve START END."
   (save-excursion
@@ -239,7 +239,8 @@ https://aplwiki.com/FinnAplIdiomLibrary"
           (t (gnu-apl-finnapl-choice-tabular)))))
 
 
-
+(declare-function helm "helm")
+(defvar helm-candidate-number-limit)
 (defun gnu-apl-finnapl-choice-helm ()
   "Present helm narrowing search buffer for FinnAPL idioms"
   (let* ((candidates

--- a/gnu-apl-follow.el
+++ b/gnu-apl-follow.el
@@ -4,18 +4,24 @@
 (require 'gnu-apl-util)
 (require 'gnu-apl-network)
 
+(declare-function gnu-apl--get-interactive-session "gnu-apl-interactive")
+(declare-function gnu-apl--name-at-point "gnu-apt-documentation")
+(declare-function gnu-apl--choose-variable "gnu-apl-editor"
+                  (prompt &optional type default-value))
+(declare-function gnu-apl--get-interactive-session-with-nocheck "gnu-apl-interactive")
+
 (defun gnu-apl--make-trace-buffer-name (varname)
   (format "*gnu-apl trace %s*" varname))
 
-;;;
-;;;  gnu-apl-trace-symbols is a list of traced symbols, each element
-;;;  has the following structure:
-;;;
-;;;    ("symbol_name" <buffer>)
-;;;
+(defvar gnu-apl-trace-variable)
+
+(defvar gnu-apl-trace-symbols nil
+  "List of traced symbols.
+Each element has the structure (\"symbol_name\" <buffer>).")
 
 (defun gnu-apl-trace-mode-kill-buffer ()
-  "If the current buffer is a trace buffer, kill the buffer. Otherwise raise an error."
+  "If the current buffer is a trace buffer, kill the buffer.
+Otherwise raise an error."
   (interactive)
   (unless (and (boundp 'gnu-apl-trace-buffer)
                gnu-apl-trace-buffer)

--- a/gnu-apl-follow.el
+++ b/gnu-apl-follow.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'cl)
+(require 'cl-lib)
 (require 'gnu-apl-util)
 (require 'gnu-apl-network)
 

--- a/gnu-apl-input.el
+++ b/gnu-apl-input.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'cl)
+(require 'cl-lib)
 (require 'quail)
 (require 'gnu-apl-symbols)
 
@@ -25,13 +25,13 @@
   (quail-install-map
    (let* ((prefix (string new))
           (gnu-apl--transcription-alist
-           (loop for command in gnu-apl--symbols
-                 for key-command = (third command)
-                 append (loop for s in (if (listp key-command)
+           (cl-loop for command in gnu-apl--symbols
+                 for key-command = (cl-third command)
+                 append (cl-loop for s in (if (listp key-command)
                                            key-command
                                          (list key-command))
                               collect (cons (concat prefix s)
-                                            (second command))))))
+                                            (cl-second command))))))
      (quail-map-from-table
       '((default gnu-apl--transcription-alist)))))
   (set-default symbol new))

--- a/gnu-apl-interactive.el
+++ b/gnu-apl-interactive.el
@@ -3,15 +3,66 @@
 (require 'cl-lib)
 (require 'gnu-apl-util)
 (require 'gnu-apl-network)
+(require 'comint)
+(require 'xref)
+
+(declare-function gnu-apl--load-help "gnu-apl-mode" (&optional string))
+(declare-function gnu-apl--choose-variable "gnu-apl-editor"
+                  (prompt &optional type default-value))
+(declare-function gnu-apl--get-function "gnu-apl-editor"
+                  (function-definition))
+(declare-function gnu-apl--name-at-point "gnu-apl-show-keyboard" ())
+(declare-function gnu-apl--init-mode-common "gnu-apl-mode" ())
+(declare-function gnu-apl--parse-function-header "gnu-apl-mode" (string))
+
+(defvar gnu-apl--symbol-doc)                ;gnu-apl-refdocs-bsd-license.el
+(defvar gnu-apl--symbols)                   ;gnu-apl-symbols.el
+(defvar gnu-apl-auto-function-editor-popup) ;gnu-apl-mode.el
+(defvar gnu-apl-use-new-native-library)     ;gnu-apl-mode.el
+(defvar gnu-apl-mode-syntax-table)          ;gnu-apl-mode.el
+
+(defvar gnu-apl-input-display-type nil
+  "Current input display type.")
+(defvar gnu-apl-preoutput-filter-state nil
+  "Current state of the (pre)output filter.")
+(defvar gnu-apl--connection nil
+  "Process object for the current connection.")
 
 (defvar gnu-apl-current-session nil
-  "The buffer that holds the currently active GNU APL session,
-or NIL if there is no active session.")
+  "The buffer that holds the currently active GNU APL session.
+The value is nil if there is no active session.")
 
 (defvar gnu-apl-libemacs-location "libemacs"
   "The location of the native code library from the interpreter.
 This shouldn't normally need to be changed except when doing
 development of the native code.")
+
+(defun gnu-apl--make-key-command-sym (n)
+  (intern (concat "insert-sym-apl-" n)))
+
+(defun gnu-apl--make-base-mode-map (prefix)
+  (let ((map (make-sparse-keymap)))
+    (dolist (command gnu-apl--symbols)
+      (let ((key-sequence (caddr command)))
+        (dolist (s (if (listp key-sequence) key-sequence (list key-sequence)))
+          (define-key map (gnu-apl--kbd (concat prefix s)) (gnu-apl--make-key-command-sym (car command))))))
+    (define-key map (kbd (concat prefix "SPC")) 'gnu-apl-insert-spc)
+    (define-key map (kbd "C-c C-k") 'gnu-apl-show-keyboard)
+    (define-key map (kbd "C-c C-h") 'gnu-apl-show-help-for-symbol)
+    (define-key map (kbd "C-c C-a") 'gnu-apl-apropos-symbol)
+    (define-key map (kbd "C-M-a") 'gnu-apl-beginning-of-defun)
+    (define-key map (kbd "C-M-e") 'gnu-apl-end-of-defun)
+    (define-key map (kbd "M-.") 'gnu-apl-find-function-at-point)
+    (define-key map (kbd "C-c C-.") 'gnu-apl-trace)
+    (define-key map (kbd "C-c C-i") 'gnu-apl-finnapl-list)
+    (define-key map [menu-bar gnu-apl] (cons "APL" (make-sparse-keymap "APL")))
+    (define-key map [menu-bar gnu-apl toggle-keyboard] '("Toggle keyboard" . gnu-apl-show-keyboard))
+    (define-key map [menu-bar gnu-apl show-help-for-symbol] '("Documentation for symbol" . gnu-apl-show-help-for-symbol))
+    (define-key map [menu-bar gnu-apl apropos-symbol] '("Search symbols" . gnu-apl-apropos-symbol))
+    (define-key map [menu-bar gnu-apl find-symbol-at-point] '("Find symbol at point" . gnu-apl-find-function-at-point))
+    (define-key map [menu-bar gnu-apl trace] '("Trace variable" . gnu-apl-trace))
+    (define-key map [menu-bar gnu-apl finnapl-list] '("FinnAPL idioms list" . gnu-apl-finnapl-list))
+    map))
 
 (defun gnu-apl-interactive-send-string (string &optional file line)
   "Send STRING to the current active interpreter.
@@ -117,9 +168,7 @@ code was read from."
 (defun gnu-apl--erase-and-set-function (name _content)
   (gnu-apl-interactive-send-string (concat "'" *gnu-apl-ignore-start* "'"))
   (gnu-apl-interactive-send-string (concat ")ERASE " name))
-  (gnu-apl-interactive-send-string (concat "'" *gnu-apl-ignore-end* "'"))
-  (setq gnu-apl-function-content-lines (split-string content "\n"))
-  (gnu-apl-interactive-send-string (concat "'" *gnu-apl-send-content-start* "'")))
+  (gnu-apl-interactive-send-string (concat "'" *gnu-apl-ignore-end* "'")))
 
 (defun gnu-apl--output-disconnected-message (output-fn)
   (funcall output-fn "The GNU APL environment has been started, but the Emacs mode was
@@ -158,8 +207,7 @@ function editor.
                     (setq gnu-apl-preoutput-filter-state 'native))
 
                    ((and gnu-apl-use-new-native-library
-                         (or (not (boundp 'gnu-apl--connection))
-                             (not (process-live-p gnu-apl--connection)))
+                         (not (process-live-p gnu-apl--connection))
                          (string-match (concat "Network listener started.*"
                                                "mode:\\([a-z]+\\) "
                                                "addr:\\([a-zA-Z0-9_/]+\\)")
@@ -180,9 +228,7 @@ function editor.
             ;; Initialising native code
             (native
              (cond ((string-match (regexp-quote *gnu-apl-network-end*) command)
-                    (unless (and (boundp 'gnu-apl--connection)
-                                 gnu-apl--connection
-                                 (process-live-p gnu-apl--connection))
+                    (unless (process-live-p gnu-apl--connection)
                       (gnu-apl--output-disconnected-message #'add-to-result))
                     (setq gnu-apl-preoutput-filter-state 'normal))
                    ((string-match (concat "Network listener started.*"
@@ -195,6 +241,10 @@ function editor.
                    (t
                     (add-to-result command))))))))
     result))
+
+(defvar gnu-apl-interactive-mode-map)
+
+(defvar gnu-apl-interactive-mode-map-prefix "s-")
 
 (defun gnu-apl--make-interactive-mode-map ()
   (let ((map (gnu-apl--make-base-mode-map gnu-apl-interactive-mode-map-prefix)))
@@ -213,10 +263,11 @@ function editor.
   (setq gnu-apl-interactive-mode-map (gnu-apl--make-interactive-mode-map)))
 
 (defcustom gnu-apl-interactive-mode-map-prefix "s-"
-  "The keymap prefix for ‘gnu-apl-interactive-mode-map’ used both to store the new value
-using ‘set-create’ and to update ‘gnu-apl-interactive-mode-map’ using
-‘gnu-apl--make-interactive-mode-map’. Kill and re-start your interactive APL
-buffers to reflect the change."
+  "The keymap prefix for `gnu-apl-interactive-mode-map'.
+It is used both to store the new value using ‘set-create’ and to
+update ‘gnu-apl-interactive-mode-map’ using
+‘gnu-apl--make-interactive-mode-map’.  Kill and re-start your
+interactive APL buffers to reflect the change."
   :type 'string
   :group 'gnu-apl
   :set 'gnu-apl--set-interactive-mode-map-prefix)
@@ -257,7 +308,7 @@ buffers to reflect the change."
           "allows you to input APL symbols by prefixing the key with a \".\" (period).\n\n"
           "There are several ")
   (insert-button "customisation"
-                 'action #'(lambda (event) (customize-group 'gnu-apl t))
+                 'action #'(lambda (_event) (customize-group 'gnu-apl t))
                  'follow-link t)
   (insert " options that can be set.\n"
           "Click the link or run M-x customize-group RET gnu-apl to set up.\n\n"
@@ -279,7 +330,7 @@ buffers to reflect the change."
             (cond ((string-match "^\\(.*\\):\\([0-9]+\\)$" reference)
                    (let ((file (match-string 1 reference))
                          (line-num (string-to-number (match-string 2 reference))))
-                     (ring-insert find-tag-marker-ring (point-marker))
+                     (xref-push-marker-stack)
                      (let ((buffer (find-buffer-visiting file)))
                        (if buffer
                            (let ((window (get-buffer-window buffer)))

--- a/gnu-apl-mode.el
+++ b/gnu-apl-mode.el
@@ -186,17 +186,14 @@ The ∇s are always flush-left, as are all lines outside of functions."
 
 (require 'gnu-apl-symbols)
 
-(defun gnu-apl--make-key-command-sym (n)
-  (intern (concat "insert-sym-apl-" n)))
-
-(macrolet ((make-insert-functions ()
-             `(progn
-                ,@(mapcar #'(lambda (command)
-                              `(defun ,(gnu-apl--make-key-command-sym (car command)) ()
-                                 (interactive)
-                                 (insert ,(cadr command))))
-                          gnu-apl--symbols))))
-  (make-insert-functions))
+;; Declare a command for every APL symbol
+(dolist (command gnu-apl--symbols)
+  (let ((name (gnu-apl--make-key-command-sym (car command)))
+	(content (cadr command)))
+    (defalias name
+      (lambda ()
+	(interactive)
+	(insert content)))))
 
 (defun gnu-apl-insert-spc ()
   "Insert a space. This is needed so that one can type a space

--- a/gnu-apl-network.el
+++ b/gnu-apl-network.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'cl)
+(require 'cl-lib)
 (require 'gnu-apl-util)
 
 (defvar *gnu-apl-end-tag* "APL_NATIVE_END_TAG")
@@ -76,10 +76,10 @@ connect mode in use."
 (defun gnu-apl--filter-network (proc output)
   (with-current-buffer (gnu-apl--get-interactive-session)
     (setq gnu-apl--current-incoming (concat gnu-apl--current-incoming output))
-    (loop with start = 0
+    (cl-loop with start = 0
           for pos = (cl-position ?\n gnu-apl--current-incoming :start start)
           while pos
-          do (let ((s (subseq gnu-apl--current-incoming start pos)))
+          do (let ((s (cl-subseq gnu-apl--current-incoming start pos)))
                (setq start (1+ pos))
 
                (cond ((string= s *gnu-apl-notification-start*)
@@ -99,8 +99,8 @@ connect mode in use."
                      (t
                       (error "Illegal state"))))
 
-          finally (when (plusp start)
-                    (setq gnu-apl--current-incoming (subseq gnu-apl--current-incoming start))))))
+          finally (when (cl-plusp start)
+                    (setq gnu-apl--current-incoming (cl-subseq gnu-apl--current-incoming start))))))
 
 (defun gnu-apl--send-network-command-and-read (command)
   (gnu-apl--send-network-command command)
@@ -117,7 +117,7 @@ connect mode in use."
 
 (defun gnu-apl--read-network-reply ()
   (with-current-buffer (gnu-apl--get-interactive-session)
-    (loop while (and (null gnu-apl--results) (process-live-p gnu-apl--connection))
+    (cl-loop while (and (null gnu-apl--results) (process-live-p gnu-apl--connection))
           do (accept-process-output gnu-apl--connection 3))
     (unless gnu-apl--results
       (signal 'gnu-apl-network-proto-error 'disconnected))
@@ -125,7 +125,7 @@ connect mode in use."
       value)))
 
 (defun gnu-apl--read-network-reply-block ()
-  (loop for line = (gnu-apl--read-network-reply)
+  (cl-loop for line = (gnu-apl--read-network-reply)
         while (not (string= line *gnu-apl-end-tag*))
         collect line))
 

--- a/gnu-apl-osx-workaround.el
+++ b/gnu-apl-osx-workaround.el
@@ -3,6 +3,8 @@
 (require 'cl-lib)
 (require 'gnu-apl-util)
 
+(defvar gnu-apl--symbols)                   ;gnu-apl-symbols.el
+
 (defun gnu-apl-update-fontset-character (spec)
   (dolist (s gnu-apl--symbols)
     (let ((char (aref (cl-second s) 0)))

--- a/gnu-apl-osx-workaround.el
+++ b/gnu-apl-osx-workaround.el
@@ -1,11 +1,11 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'cl)
+(require 'cl-lib)
 (require 'gnu-apl-util)
 
 (defun gnu-apl-update-fontset-character (spec)
   (dolist (s gnu-apl--symbols)
-    (let ((char (aref (second s) 0)))
+    (let ((char (aref (cl-second s) 0)))
       (when (> char 255)
         (set-fontset-font t (cons char char) (font-spec :family spec)))))
   (set-fontset-font t '(#x2500 . #x2594) (font-spec :family spec)))

--- a/gnu-apl-plot.el
+++ b/gnu-apl-plot.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'cl)
+(require 'cl-lib)
 (require 'gnu-apl-util)
 (require 'gnu-apl-network)
 
@@ -37,7 +37,7 @@ from the APL runtime"
            (listp (car value)))))
 
 (defun gnu-apl--plot-insert-cell (entry)
-  (etypecase entry
+  (cl-etypecase entry
     (integer (insert (format "%d" entry)))
     (number (insert (format "%f" entry)))
     (string (insert (format "\"%s\"" entry)))
@@ -62,7 +62,7 @@ from the APL runtime"
 
 (defun gnu-apl--write-array-content-to-csv (content)
   (cond ((gnu-apl--single-dimension-p content)
-         (loop for value in content
+         (cl-loop for value in content
                do (progn
                     (insert (gnu-apl--cell-value-as-string value))
                     (insert "\n")))
@@ -71,8 +71,8 @@ from the APL runtime"
          (let ((size (cadr content)))
            (unless (= (length size) 2)
              (error "Unexpected dimensions: %d" (length size)))
-           (loop for row-value in (caddr content)
-                 do (loop for col-content in row-value
+           (cl-loop for row-value in (caddr content)
+                 do (cl-loop for col-content in row-value
                           for first = t then nil
                           when (not first)
                           do (insert " ")

--- a/gnu-apl-plot.el
+++ b/gnu-apl-plot.el
@@ -4,6 +4,12 @@
 (require 'gnu-apl-util)
 (require 'gnu-apl-network)
 
+(declare-function gnu-apl--name-at-point "gnu-apl-documentation" ())
+(declare-function gnu-apl--choose-variable "gnu-apl-editor"
+		  (prompt &optional type default-value))
+
+(defvar gnu-apl-gnuplot-program)	;gnu-apl-mode.el
+
 (cl-defmacro gnu-apl--with-temp-files (files &body body)
   (declare (indent 1))
   (if files

--- a/gnu-apl-refdocs-bsd-license.el
+++ b/gnu-apl-refdocs-bsd-license.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'cl)
+(require 'cl-lib)
 (require 'gnu-apl-util)
 
 (defvar gnu-apl--symbol-doc

--- a/gnu-apl-spreadsheet.el
+++ b/gnu-apl-spreadsheet.el
@@ -5,6 +5,12 @@
 (require 'gnu-apl-network)
 (require 'ses)
 
+(declare-function gnu-apl--send "gnu-apl-interactive" (proc string))
+(declare-function gnu-apl--get-interactive-session "gnu-apl-interactive" ())
+(declare-function gnu-apl--name-at-point "gnu-apl-documentation" ())
+(declare-function gnu-apl--choose-variable "gnu-apl-editor"
+                  (prompt &optional type default-value))
+
 (defun gnu-apl--string-to-apl-expression (string)
   "Escape quotes in an APL string. If the string contains
 non-printable characters, generate a full expression. For now,
@@ -64,8 +70,8 @@ the active interpreter."
 
 (define-minor-mode gnu-apl-spreadsheet-mode
   "A variation of ‘ses-mode’ to be used for editing APL matrices."
-  nil
-  " ≡"
+  :lighter " ≡"
+  :keymap
   (list (cons (kbd "C-c C-c") 'gnu-apl-spreadsheet-send-to-variable)
         (cons [menu-bar gnu-apl] (cons "APL" (make-sparse-keymap "APL")))
         (cons [menu-bar gnu-apl send-this-document] '("Send document" . gnu-apl-spreadsheet-send-this-document))
@@ -123,6 +129,9 @@ value of VARNAME to the content of the spreadsheet."
 values as the spreadsheet in the current buffer."
   (concat (gnu-apl-make-array-loading-instructions varname)))
 
+(defvar ses--numrows)                   ;ses.el
+(defvar ses--numcols)                   ;ses.el
+(defvar ses--cells)                     ;ses.el
 (defun gnu-apl-make-array-loading-instructions (var-name)
   "Return APL instructions that sets variable VAR-NAME to the
 content of the spreadsheet in this buffer."

--- a/gnu-apl-symbols.el
+++ b/gnu-apl-symbols.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'cl)
+(require 'cl-lib)
 (require 'quail)
 (require 'gnu-apl-util)
 

--- a/gnu-apl-util.el
+++ b/gnu-apl-util.el
@@ -1,6 +1,6 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'cl)
+(require 'cl-lib)
 
 (cl-defun gnu-apl--trim (regexp string &optional (start t) (end t))
   (if (or start end)
@@ -31,7 +31,7 @@
 
 (defun gnu-apl--string-match-start (string key)
   (and (>= (length string) (length key))
-       (string= (subseq string 0 (length key)) key)))
+       (string= (cl-subseq string 0 (length key)) key)))
 
 (defun gnu-apl--kbd (definition)
   (if (functionp #'kbd)
@@ -72,7 +72,7 @@
 
 (unless (fboundp 'cl-find)
   (defun cl-find (&rest args)
-    (apply #'find args)))
+    (apply #'cl-find args)))
 
 (unless (fboundp 'cl-defun)
   (defmacro cl-defun (&rest args)
@@ -84,6 +84,6 @@
 
 (unless (fboundp 'cl-remove-if-not)
   (defun cl-remove-if-not (&rest args)
-    (apply #'remove-if-not args)))
+    (apply #'cl-remove-if-not args)))
 
 (provide 'gnu-apl-util)


### PR DESCRIPTION
Hi,

I would like to add gnu-apl-mode to [NonGNU ELPA](http://elpa.nongnu.org/), but before that is done, a few code issues should be fixed. The attached patches improve remove the deprecated cl library, and fix a number of issues raised by the byte compiler (see commit description).

If you decide to apply these changes, it would be necessary to bump the [version attribute in the main file](https://github.com/lokedhs/gnu-apl-mode/blob/master/gnu-apl-mode.el#L6), so that ELPA recognizes a new release with these improvements.