### PR TITLE
Add minimal headers to all Emacs Lisp files

### DIFF
--- a/gnu-apl-documentation.el
+++ b/gnu-apl-documentation.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-documentation.el --- Documentation GNU APL -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)

--- a/gnu-apl-editor.el
+++ b/gnu-apl-editor.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-editor.el --- Editing GNU APL -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)
@@ -271,3 +275,4 @@ characters."
     (read-only-mode 1)))
 
 (provide 'gnu-apl-editor)
+;;; gnu-apl-editor.el ends here

--- a/gnu-apl-finnapl.el
+++ b/gnu-apl-finnapl.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-finnapl.el --- FinnAPL support -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'tabulated-list)
@@ -261,3 +265,4 @@ https://aplwiki.com/FinnAplIdiomLibrary"
 
 
 (provide 'gnu-apl-finnapl)
+;;; gnu-apl-finnapl.el ends here

--- a/gnu-apl-follow.el
+++ b/gnu-apl-follow.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-follow.el --- GNU APL Tracing support -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)
@@ -134,3 +138,4 @@ content."
         (switch-to-buffer-other-window b)))))
 
 (provide 'gnu-apl-follow)
+;;; gnu-apl-follow.el ends here

--- a/gnu-apl-input.el
+++ b/gnu-apl-input.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-input.el --- Input method for GNU APL -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'quail)
@@ -48,3 +52,4 @@
   :set #'gnu-apl--update-key-prefix)
 
 (provide 'gnu-apl-input)
+;;; gnu-apl-input.el ends here

--- a/gnu-apl-interactive.el
+++ b/gnu-apl-interactive.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-interactive.el --- Interaction support for GNU APL -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)
@@ -352,3 +356,4 @@ interactive APL buffers to reflect the change."
     (goto-char (point-max))))
 
 (provide 'gnu-apl-interactive)
+;;; gnu-apl-interactive.el ends here

--- a/gnu-apl-mode.el
+++ b/gnu-apl-mode.el
@@ -1,32 +1,32 @@
-;;; gnu-apl-mode --- Emacs mode for GNU APL -*- lexical-binding: t -*-
-;;;
-;;; Copyright (C) 2013-2015 Elias Mårtenson
-;;;
-;;; Author: Elias Mårtenson <lokedhs@gmail.com>
-;;; Version: 1.5.0
-;;; Keywords: languages
-;;; URL: http://www.gnu.org/software/apl/
-;;;
+;;; gnu-apl-mode.el --- Emacs mode for GNU APL -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;; Author: Elias Mårtenson <lokedhs@gmail.com>
+;; Version: 1.5.1
+;; Keywords: languages
+;; URL: http://www.gnu.org/software/apl/
+
 ;;; Commentary:
-;;;
-;;; Emacs mode for GNU APL
-;;;
-;;; This mode provides both normal editing facilities for APL code as
-;;; well as an interactive mode. The interactive mode is started using
-;;; the command ‘gnu-apl’.
-;;;
-;;; The mode provides two different ways to input APL symbols. The
-;;; first method is enabled by default, and simply binds keys with the
-;;; "super" modifier. The problem with this method is that the "super"
-;;; modifier has to be enabled, and any shortcuts added by the
-;;; operating system that uses this key has to be changed.
-;;;
-;;; The other method is a bit more cumbersome to use, but it's pretty
-;;; much guaranteed to work everywhere. Simply enable the input mode
-;;; using C-\ (‘toggle-input-method’) and choose APL-Z. Once this mode
-;;; is enabled, press "." (period) followed by a letter to generate
-;;; the corresponding symbol.
-;;;
+
+;; Emacs mode for GNU APL
+;;
+;; This mode provides both normal editing facilities for APL code as
+;; well as an interactive mode. The interactive mode is started using
+;; the command ‘gnu-apl’.
+;;
+;; The mode provides two different ways to input APL symbols. The
+;; first method is enabled by default, and simply binds keys with the
+;; "super" modifier. The problem with this method is that the "super"
+;; modifier has to be enabled, and any shortcuts added by the
+;; operating system that uses this key has to be changed.
+;;
+;; The other method is a bit more cumbersome to use, but it's pretty
+;; much guaranteed to work everywhere. Simply enable the input mode
+;; using C-\ (‘toggle-input-method’) and choose APL-Z. Once this mode
+;; is enabled, press "." (period) followed by a letter to generate
+;; the corresponding symbol.
+
 ;;; Code:
 
 (require 'cl-lib)
@@ -594,3 +594,4 @@ to ‘gnu-apl-executable’)."
   (speedbar-add-supported-extension ".apl"))
 
 (provide 'gnu-apl-mode)
+;;; gnu-apl-mode.el ends here

--- a/gnu-apl-network.el
+++ b/gnu-apl-network.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-interactive.el --- Networking support for GNU APL -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)
@@ -144,3 +148,4 @@ connect mode in use."
         collect line))
 
 (provide 'gnu-apl-network)
+;;; gnu-apl-network.el ends here

--- a/gnu-apl-osx-workaround.el
+++ b/gnu-apl-osx-workaround.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-osx-workaround.el.el --- GNU APL support for OSX -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)
@@ -13,3 +17,4 @@
   (set-fontset-font t '(#x2500 . #x2594) (font-spec :family spec)))
 
 (provide 'gnu-apl-osx-workaround)
+;;; gnu-apl-osx-workaround.el ends here

--- a/gnu-apl-plot.el
+++ b/gnu-apl-plot.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-plot.el --- Plotting support for GNU APL -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)
@@ -123,3 +127,4 @@ dimension of the exported data as a list of the form (ROWS COLS)"
     (shell-command (format "%s -p %s" gnu-apl-gnuplot-program script-file))))
 
 (provide 'gnu-apl-plot)
+;;; gnu-apl-plot.el ends here

--- a/gnu-apl-refdocs-bsd-license.el
+++ b/gnu-apl-refdocs-bsd-license.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-refdocs-bsd-license.el --- GNU APL symbol documentation -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)
@@ -390,3 +394,4 @@ of the monadic operator, name of the dyadic operator, description
 of the dyadic operator, extra documentation.")
 
 (provide 'gnu-apl-refdocs-bsd-license)
+;;; gnu-apl-refdocs-bsd-license.el ends here

--- a/gnu-apl-spreadsheet.el
+++ b/gnu-apl-spreadsheet.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-spreadsheet.el --- Spreadsheet support for GNU APL -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'gnu-apl-util)
@@ -155,3 +159,4 @@ content of the spreadsheet in this buffer."
       (princ (format "%s←(%d %d)⍴%s" var-name rows cols var-name)))))
 
 (provide 'gnu-apl-spreadsheet)
+;;; gnu-apl-spreadsheet.el ends here

--- a/gnu-apl-symbols.el
+++ b/gnu-apl-symbols.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-symbols.el --- List of GNU APL Symbols -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 (require 'quail)
@@ -162,3 +166,4 @@
                            ))
 
 (provide 'gnu-apl-symbols)
+;;; gnu-apl-symbols.el ends here

--- a/gnu-apl-util.el
+++ b/gnu-apl-util.el
@@ -1,4 +1,8 @@
-;;; -*- lexical-binding: t -*-
+;;; gnu-apl-util.el --- Utility functionality for `gnu-apl-mode' -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013-2015 Elias Mårtenson
+
+;;; Code:
 
 (require 'cl-lib)
 
@@ -87,3 +91,4 @@
     (apply #'cl-remove-if-not args)))
 
 (provide 'gnu-apl-util)
+;;; gnu-apl-util.el ends here


### PR DESCRIPTION
This is related to #42. The ELPA build system requires each file to have a minimal header. I didn't touch the copyright notices, it is up to you to update them or not.